### PR TITLE
feat: JwtFilter 선택적 인증 모드 추가

### DIFF
--- a/src/main/java/com/example/hiddencountry/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/hiddencountry/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.example.hiddencountry.global.util.SecurityConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -53,6 +54,7 @@ public class SecurityConfig {
 		// 경로별 인가 설정
 		http.authorizeHttpRequests(auth -> auth
 				.requestMatchers(SecurityConstants.ALLOW_URLS.toArray(new String[0])).permitAll()
+				.requestMatchers(HttpMethod.GET, SecurityConstants.GET__METHOD_ALLOW_URLS.toArray(new String[0])).permitAll()
 				.anyRequest().authenticated()
 		);
 

--- a/src/main/java/com/example/hiddencountry/global/util/SecurityConstants.java
+++ b/src/main/java/com/example/hiddencountry/global/util/SecurityConstants.java
@@ -16,8 +16,12 @@ public class SecurityConstants {
             "/place",
             "/swagger-ui.html",
             "/swagger-ui/**",
-            "/v3/api-docs/**",
-            "/places",
-            "/places/map"
+            "/v3/api-docs/**"
+    );
+
+    /// 토큰이 있을 경우 인증 절차 진행하지만, 없을 경우에도 예외를 발생시키지는 않는 GET 메서드 URL
+    public static final List<String> GET__METHOD_ALLOW_URLS = List.of(
+        "/places",
+        "/places/map"
     );
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈번호
- Closes #36 


## ✅ PR 작업 내역 요약
- JwtFilter에 선택적 인증 모드 추가
- 인증 흐름을 스킵 / 선택적 인증 / 강제 인증 3단계로 확장
- 요청 경로별로 인증 모드 지정 가능하도록 security constant 파일에 경로 추가

## 📝 변경 사항
- JwtFilter 로직에 토큰이 없으면 스킵, 있으면 검증 로직 추가
- 장소 리스트 API에 선택적 인증 적용
