### PR TITLE
Add local review load-test docs, Docker MySQL setup, k6 scenarios, and seed/drop SQL

### DIFF
--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -1,0 +1,165 @@
+# 리뷰 조회 성능 실험 가이드 (로컬 전용: Docker 분리 DB + 대량 데이터 + k6)
+
+요청하신 목적에 맞게, **로컬에서 Docker로 테스트 DB를 분리**하고,
+**대량 리뷰 데이터를 넣은 뒤**, **인덱스 없는 상태에서 조회 성능을 먼저 측정**하는 절차를 정리했습니다.
+
+> ⚠️ 이 문서의 절차는 **배포 환경용이 아닙니다. 로컬 성능 실험 전용**입니다.
+> 운영/스테이징 DB에 `seed` 또는 `drop index` 스크립트를 실행하면 안 됩니다.
+
+구성 파일
+- Docker DB: `docs/performance/review-loadtest/docker/docker-compose.yml`
+- 데이터 적재 SQL: `docs/performance/review-loadtest/sql/seed-review-data.sql`
+- 인덱스 제거 SQL(보조 인덱스 제거): `docs/performance/review-loadtest/sql/drop-review-secondary-indexes.sql`
+- k6 스크립트: `docs/performance/review-loadtest/k6/review-list-no-index.js`
+
+---
+
+## 0) 사전 준비
+
+- Docker / Docker Compose
+- MySQL 클라이언트 (`mysql`)
+- k6
+- 백엔드 앱 실행 가능 상태 (Spring Boot)
+
+> 기본 포트
+> - MySQL: `3307` (컨테이너 `3306` 매핑)
+> - 앱: `8080`
+
+---
+
+## 1) Docker로 테스트 DB 올리기
+
+```bash
+docker compose -f docs/performance/review-loadtest/docker/docker-compose.yml up -d
+```
+
+> 위 compose 파일은 로컬 머신에서만 실행하세요.
+
+상태 확인:
+
+```bash
+docker ps | grep review-perf-mysql
+```
+
+접속 정보:
+- host: `127.0.0.1`
+- port: `3307`
+- db: `hiddencountry_perf`
+- user: `perf`
+- pass: `perf`
+
+---
+
+## 2) 앱을 테스트 DB로 연결해서 스키마 생성
+
+중요: 이 단계부터는 **로컬 실행 프로필**(예: `dev`, `local-perf`)에서만 수행하세요.
+
+이 프로젝트는 JPA 기반이라 앱이 한번 뜨면서 테이블을 만들도록 설정하면 편합니다.
+(예: `spring.jpa.hibernate.ddl-auto=update` 또는 `create`를 테스트 프로필에서 사용)
+
+예시 실행 환경 변수:
+
+```bash
+SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3307/hiddencountry_perf?useSSL=false&serverTimezone=Asia/Seoul \
+SPRING_DATASOURCE_USERNAME=perf \
+SPRING_DATASOURCE_PASSWORD=perf \
+SPRING_JPA_HIBERNATE_DDL_AUTO=update \
+./gradlew bootRun
+```
+
+앱이 뜬 뒤에는 종료해도 됩니다. (테이블 생성 목적)
+
+---
+
+## 3) 대량 리뷰 데이터 삽입
+
+아래 명령은 테스트 DB를 비우고 다시 채우므로, 반드시 로컬 테스트 DB에만 실행하세요.
+
+```bash
+mysql -h 127.0.0.1 -P 3307 -u perf -pperf hiddencountry_perf \
+  < docs/performance/review-loadtest/sql/seed-review-data.sql
+```
+
+기본 삽입량:
+- 사용자: 1,000명
+- 장소: 1건
+- 리뷰: 200,000건
+- 리뷰 이미지: 리뷰의 약 30%
+
+스크립트 마지막에 `target_place_id`를 출력하므로 값을 메모하세요.
+
+---
+
+## 4) 인덱스 없는 상태 맞추기 (측정 전)
+
+요청하신 대로 "인덱스 적용 전" 측정을 위해, `review` 테이블의 **보조 인덱스만 제거**합니다.
+(PK는 유지)
+
+이 단계도 로컬 테스트 DB에서만 실행하세요.
+
+```bash
+mysql -h 127.0.0.1 -P 3307 -u perf -pperf hiddencountry_perf \
+  < docs/performance/review-loadtest/sql/drop-review-secondary-indexes.sql
+```
+
+이후 `SHOW INDEX FROM review;` 결과에서 `PRIMARY`만 남았는지 확인합니다.
+
+---
+
+## 5) 백엔드 앱 실행 (테스트 DB 연결)
+
+```bash
+SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3307/hiddencountry_perf?useSSL=false&serverTimezone=Asia/Seoul \
+SPRING_DATASOURCE_USERNAME=perf \
+SPRING_DATASOURCE_PASSWORD=perf \
+SPRING_JPA_HIBERNATE_DDL_AUTO=none \
+./gradlew bootRun
+```
+
+> 측정 단계에서는 `ddl-auto=none` 권장 (테이블/인덱스 자동 변경 방지).
+
+---
+
+## 6) k6로 리뷰 조회 성능 측정 (No Index Baseline)
+
+```bash
+BASE_URL=http://localhost:8080 \
+PLACE_ID=<3단계에서 출력된 target_place_id> \
+PAGE_SIZE=20 \
+k6 run docs/performance/review-loadtest/k6/review-list-no-index.js
+```
+
+스크립트 특징:
+- `LATEST` / `RATING_DESC`를 분리 시나리오로 동시 실행
+- 각 VU가 커서 기반으로 최대 3페이지 연속 조회
+- 태그(`sort`) 기준으로 정렬별 p95 비교 가능
+
+---
+
+## 7) 측정 결과 기록 (Baseline)
+
+권장 기록표:
+
+| 항목 | 값 |
+|---|---:|
+| p95 (LATEST) |  |
+| p95 (RATING_DESC) |  |
+| 에러율 |  |
+| RPS |  |
+| DB CPU/Connections |  |
+
+Actuator 같이 보기:
+- `/actuator/metrics/http.server.requests`
+- `/actuator/metrics/hikaricp.connections.active`
+- `/actuator/metrics/jvm.threads.live`
+
+---
+
+## 8) 그 다음 개선 순서 (Baseline 이후)
+
+1. 인덱스 적용 (예: `(place_id, id)`, `(place_id, score, id)`)
+2. 동일한 k6 시나리오 재실행
+3. Baseline과 비교표 작성
+4. 필요 시 N+1 완화, DTO 경량화, 쿼리 튜닝으로 2차 개선
+
+핵심: **먼저 Baseline, 그 다음 개선**.

--- a/docs/performance/k6-review-list.js
+++ b/docs/performance/k6-review-list.js
@@ -1,0 +1,60 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  scenarios: {
+    review_list_latest: {
+      executor: 'ramping-vus',
+      startVUs: 1,
+      stages: [
+        { duration: '20s', target: 10 },
+        { duration: '40s', target: 30 },
+        { duration: '20s', target: 0 },
+      ],
+      exec: 'latestScenario',
+    },
+    review_list_rating: {
+      executor: 'ramping-vus',
+      startVUs: 1,
+      stages: [
+        { duration: '20s', target: 5 },
+        { duration: '40s', target: 15 },
+        { duration: '20s', target: 0 },
+      ],
+      exec: 'ratingScenario',
+      startTime: '5s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<2000'],
+    'http_req_duration{scenario:latest}': ['p(95)<2000'],
+    'http_req_duration{scenario:rating}': ['p(95)<2000'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const PLACE_ID = __ENV.PLACE_ID || '1';
+const SIZE = __ENV.SIZE || '10';
+
+export function latestScenario() {
+  const url = `${BASE_URL}/review/${PLACE_ID}?sort=LATEST&size=${SIZE}`;
+  const res = http.get(url, { tags: { scenario: 'latest' } });
+
+  check(res, {
+    'latest status is 2xx': (r) => r.status >= 200 && r.status < 300,
+  });
+
+  sleep(0.5);
+}
+
+export function ratingScenario() {
+  const url = `${BASE_URL}/review/${PLACE_ID}?sort=RATING_DESC&size=${SIZE}`;
+  const res = http.get(url, { tags: { scenario: 'rating' } });
+
+  check(res, {
+    'rating status is 2xx': (r) => r.status >= 200 && r.status < 300,
+  });
+
+  sleep(0.5);
+}

--- a/docs/performance/review-loadtest/docker/docker-compose.yml
+++ b/docs/performance/review-loadtest/docker/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.9'
+services:
+  review-perf-mysql:
+    image: mysql:8.0
+    container_name: review-perf-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: hiddencountry_perf
+      MYSQL_USER: perf
+      MYSQL_PASSWORD: perf
+      TZ: Asia/Seoul
+    ports:
+      - "3307:3306"
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --max_connections=300
+      - --innodb_buffer_pool_size=512M
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - review_perf_mysql_data:/var/lib/mysql
+
+volumes:
+  review_perf_mysql_data:

--- a/docs/performance/review-loadtest/k6/review-list-no-index.js
+++ b/docs/performance/review-loadtest/k6/review-list-no-index.js
@@ -1,0 +1,96 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const PLACE_ID = __ENV.PLACE_ID || '1';
+const PAGE_SIZE = __ENV.PAGE_SIZE || '20';
+const THINK_TIME = Number(__ENV.THINK_TIME || '0.2');
+
+function fetchPage(sort, cursorId, cursorScore) {
+  let url = `${BASE_URL}/review/${PLACE_ID}?sort=${sort}&size=${PAGE_SIZE}`;
+
+  if (cursorId) {
+    url += `&cursorId=${cursorId}`;
+  }
+  if (cursorScore !== null && cursorScore !== undefined) {
+    url += `&cursorScore=${cursorScore}`;
+  }
+
+  return http.get(url, {
+    tags: { endpoint: 'review_list', sort },
+  });
+}
+
+function runCursorFlow(sort) {
+  let cursorId = null;
+  let cursorScore = null;
+
+  for (let i = 0; i < 3; i++) {
+    const res = fetchPage(sort, cursorId, cursorScore);
+
+    const ok = check(res, {
+      [`${sort} status is 2xx`]: (r) => r.status >= 200 && r.status < 300,
+      [`${sort} body has data`]: (r) => {
+        const data = r.json('data');
+        return data !== null && data !== undefined;
+      },
+    });
+
+    if (!ok) {
+      return;
+    }
+
+    const hasNext = res.json('data.hasNext');
+    cursorId = res.json('data.nextId');
+
+    if (sort === 'RATING_DESC') {
+      cursorScore = res.json('data.nextScore');
+    }
+
+    if (!hasNext || !cursorId) {
+      return;
+    }
+
+    sleep(THINK_TIME);
+  }
+}
+
+export const options = {
+  scenarios: {
+    latest_no_index: {
+      executor: 'ramping-vus',
+      startVUs: 1,
+      stages: [
+        { duration: '30s', target: 20 },
+        { duration: '1m', target: 60 },
+        { duration: '30s', target: 0 },
+      ],
+      exec: 'latestScenario',
+    },
+    rating_no_index: {
+      executor: 'ramping-vus',
+      startVUs: 1,
+      stages: [
+        { duration: '30s', target: 10 },
+        { duration: '1m', target: 30 },
+        { duration: '30s', target: 0 },
+      ],
+      exec: 'ratingScenario',
+      startTime: '10s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<3000'],
+    'http_req_duration{sort:LATEST}': ['p(95)<3000'],
+    'http_req_duration{sort:RATING_DESC}': ['p(95)<3000'],
+  },
+};
+
+export function latestScenario() {
+  runCursorFlow('LATEST');
+}
+
+export function ratingScenario() {
+  runCursorFlow('RATING_DESC');
+}

--- a/docs/performance/review-loadtest/sql/drop-review-secondary-indexes.sql
+++ b/docs/performance/review-loadtest/sql/drop-review-secondary-indexes.sql
@@ -1,0 +1,32 @@
+-- 리뷰 조회 테스트를 '인덱스 없는 상태'로 맞추기 위한 스크립트
+-- PK는 유지하고, review 테이블의 보조 인덱스만 제거합니다.
+-- 실행 예:
+-- mysql -h 127.0.0.1 -P 3307 -u perf -pperf hiddencountry_perf < docs/performance/review-loadtest/sql/drop-review-secondary-indexes.sql
+
+SET @db := DATABASE();
+
+SELECT index_name
+FROM information_schema.statistics
+WHERE table_schema = @db
+  AND table_name = 'review'
+  AND index_name <> 'PRIMARY';
+
+SET @drop_sql = (
+  SELECT IFNULL(
+    GROUP_CONCAT(CONCAT('DROP INDEX `', index_name, '` ON `review`') SEPARATOR '; '),
+    'SELECT "no secondary index"'
+  )
+  FROM (
+    SELECT DISTINCT index_name
+    FROM information_schema.statistics
+    WHERE table_schema = @db
+      AND table_name = 'review'
+      AND index_name <> 'PRIMARY'
+  ) t
+);
+
+PREPARE stmt FROM @drop_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SHOW INDEX FROM review;

--- a/docs/performance/review-loadtest/sql/seed-review-data.sql
+++ b/docs/performance/review-loadtest/sql/seed-review-data.sql
@@ -1,0 +1,102 @@
+-- 리뷰 조회 부하테스트용 대량 데이터 적재 스크립트 (MySQL 8)
+-- 실행 예:
+-- mysql -h 127.0.0.1 -P 3307 -u perf -pperf hiddencountry_perf < docs/performance/review-loadtest/sql/seed-review-data.sql
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+TRUNCATE TABLE review_tag;
+TRUNCATE TABLE review_image;
+TRUNCATE TABLE review;
+TRUNCATE TABLE place_country;
+TRUNCATE TABLE place;
+TRUNCATE TABLE `user`;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- 1) 사용자 1,000명 생성
+CREATE TEMPORARY TABLE seq_1000 AS
+SELECT d0.n + d1.n * 10 + d2.n * 100 + 1 AS n
+FROM
+  (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL
+   SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d0
+CROSS JOIN
+  (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL
+   SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d1
+CROSS JOIN
+  (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL
+   SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) d2
+WHERE d0.n + d1.n * 10 + d2.n * 100 < 1000;
+
+INSERT INTO `user` (kakao_id, nickname, profile_image, created_at, updated_at)
+SELECT
+  900000000 + n,
+  CONCAT('perf_user_', LPAD(n, 4, '0')),
+  CONCAT('https://example.com/u/', n, '.png'),
+  NOW(), NOW()
+FROM seq_1000;
+
+-- 2) 테스트용 place 1건 생성 (id는 auto increment)
+INSERT INTO place (
+  addr1, addr2, cat1, content_id, content_type, area_code,
+  first_image, first_image2, mapx, mapy, title, r_season,
+  review_count, review_score_average, view_count, is_review_image
+) VALUES (
+  '서울특별시 중구 세종대로 110',
+  '성능테스트용 장소',
+  'A01',
+  1000001,
+  12,
+  '1',
+  'https://example.com/place/1.jpg',
+  'https://example.com/place/1_2.jpg',
+  126.9780,
+  37.5665,
+  '성능테스트 장소',
+  'ALL',
+  0,
+  0,
+  0,
+  0
+);
+
+-- 3) 리뷰 대량 생성
+-- 기본 200,000건. 필요 시 아래 값을 변경하세요.
+SET @review_count := 200000;
+SET @place_id := (SELECT id FROM place ORDER BY id DESC LIMIT 1);
+SET @max_user_id := (SELECT MAX(id) FROM `user`);
+SET @row_num := 0;
+
+INSERT INTO review (content, score, place_id, user_id, created_at, updated_at)
+SELECT
+  CONCAT('부하테스트 리뷰 #', @row_num := @row_num + 1),
+  1 + ((@row_num - 1) MOD 5),
+  @place_id,
+  1 + ((@row_num - 1) MOD @max_user_id),
+  NOW() - INTERVAL ((@row_num - 1) MOD 100000) SECOND,
+  NOW() - INTERVAL ((@row_num - 1) MOD 100000) SECOND
+FROM seq_1000 a
+CROSS JOIN seq_1000 b
+LIMIT @review_count;
+
+-- 4) 이미지 데이터 일부 생성 (리뷰의 약 30%)
+INSERT INTO review_image (url, review_id, created_at, updated_at)
+SELECT
+  CONCAT('https://example.com/review/', r.id, '.jpg'),
+  r.id,
+  NOW(), NOW()
+FROM review r
+WHERE MOD(r.id, 10) < 3;
+
+-- 5) place 집계 컬럼 보정
+UPDATE place p
+SET
+  review_count = (SELECT COUNT(*) FROM review r WHERE r.place_id = p.id),
+  review_score_average = (SELECT IFNULL(AVG(r.score), 0) FROM review r WHERE r.place_id = p.id)
+WHERE p.id = @place_id;
+
+DROP TEMPORARY TABLE IF EXISTS seq_1000;
+
+SELECT
+  @place_id AS target_place_id,
+  (SELECT COUNT(*) FROM review WHERE place_id = @place_id) AS review_count,
+  (SELECT COUNT(*) FROM review_image ri JOIN review r ON ri.review_id = r.id WHERE r.place_id = @place_id) AS image_count;


### PR DESCRIPTION
### Motivation

- Provide a repeatable, local-only procedure to measure review list query performance using a separated Docker MySQL instance and large synthetic data set. 
- Measure a baseline "no secondary index" scenario before applying index optimizations to validate index impact. 

### Description

- Add a guide at `docs/performance/README.md` that documents setup steps, commands, and the recommended measurement workflow. 
- Add a Docker Compose file at `docs/performance/review-loadtest/docker/docker-compose.yml` to run a local MySQL 8 instance on port `3307`. 
- Add a large-data seeder `docs/performance/review-loadtest/sql/seed-review-data.sql` which generates users, one test `place`, ~200,000 `review` rows and ~30% review images and prints `target_place_id`. 
- Add a safe index-drop script `docs/performance/review-loadtest/sql/drop-review-secondary-indexes.sql` that removes non-PK indexes on `review` to create the no-index baseline. 
- Add k6 load test scripts `docs/performance/k6-review-list.js` and `docs/performance/review-loadtest/k6/review-list-no-index.js` with scenarios, VU ramps, cursor-based paging flows, and thresholds for `LATEST` and `RATING_DESC` sorts. 

### Testing

- No automated CI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b75bff8f8c83229f9fc04ac52d0ad3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 문서화
  * 로컬 성능 테스트 가이드 추가: 로컬 DB 구성, 대용량 데이터 적재, 보조 인덱스 제거, 애플리케이션·k6 실행, p95·오류율·RPS 기록 및 비교 절차 제공.
* 테스트
  * k6 부하 테스트 시나리오 추가: 최신/평점 정렬 리뷰 목록 테스트, 램핑 단계와 시나리오별 임계값(p95 < 2초, 실패율 < 5%) 적용, 커서 기반 페이징 흐름 검증.
* 작업
  * 성능용 MySQL Docker Compose 환경 제공(헬스체크·리소스 설정 포함).
  * 대용량 데이터 시드 및 보조 인덱스 일괄 제거 SQL 스크립트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->